### PR TITLE
Script change suggestions

### DIFF
--- a/scripts/close_inactive_prs.ps1
+++ b/scripts/close_inactive_prs.ps1
@@ -68,7 +68,7 @@ function Get-GhPrList {
         [string]$CutoffDate
     )
 
-    $searchQuery = "is:pr updated:<$CutoffDate -label:$NoStaleLabel"
+    $searchQuery = "is:pr updated:<$CutoffDate -label:$NoStaleLabel sort:updated-asc"
     $command = @('pr', 'list', '--repo', $Repo, '--state', 'open', '--limit', $Limit.ToString(), '--search', $searchQuery, '--json', 'number,title,url,updatedAt,labels,author')
     $result = Invoke-GhCommand -Arguments $command
 

--- a/scripts/close_inactive_prs.ps1
+++ b/scripts/close_inactive_prs.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.0
+
 param(
     [ValidateRange(1, [int]::MaxValue)]
     [int]$Age = 120,
@@ -9,6 +11,13 @@ param(
 
     [string]$OutputFile,
 
+    [ValidateScript({
+        if ($_ -and -not (Test-Path -LiteralPath $_ -PathType Leaf)) {
+            throw '-CloseWithComment requires a valid markdown file path.'
+        }
+
+        $true
+    })]
     [string]$CloseWithComment
 )
 
@@ -53,10 +62,14 @@ function Get-GhPrList {
         [string]$Repo,
 
         [Parameter(Mandatory)]
-        [int]$Limit
+        [int]$Limit,
+
+        [Parameter(Mandatory)]
+        [string]$CutoffDate
     )
 
-    $command = @('pr', 'list', '--repo', $Repo, '--state', 'open', '--limit', $Limit.ToString(), '--json', 'number,title,url,updatedAt,labels,author')
+    $searchQuery = "is:pr updated:<$CutoffDate -label:$NoStaleLabel"
+    $command = @('pr', 'list', '--repo', $Repo, '--state', 'open', '--limit', $Limit.ToString(), '--search', $searchQuery, '--json', 'number,title,url,updatedAt,labels,author')
     $result = Invoke-GhCommand -Arguments $command
 
     if ($result.ExitCode -ne 0) {
@@ -79,43 +92,6 @@ function Get-AgeDays {
     return [int][Math]::Floor(((Get-Date).ToUniversalTime() - $updatedUtc).TotalDays)
 }
 
-function Get-PropertyValue {
-    param(
-        [Parameter(Mandatory)][object]$InputObject,
-        [Parameter(Mandatory)][string]$Name,
-        [object]$Default = ''
-    )
-
-    if ($InputObject -is [System.Collections.IDictionary]) {
-        if ($InputObject.Contains($Name)) {
-            return $InputObject[$Name]
-        }
-
-        return $Default
-    }
-
-    $property = $InputObject.PSObject.Properties[$Name] -as [System.Management.Automation.PSNoteProperty]
-    if ($null -ne $property) {
-        return $property.Value
-    }
-
-    return $Default
-}
-
-function Test-StalePullRequest {
-    param(
-        [Parameter(Mandatory)][hashtable]$Pr,
-        [Parameter(Mandatory)][int]$AgeDays
-    )
-
-    $labels = @($Pr.labels | ForEach-Object { $_.name })
-    if ($NoStaleLabel -in $labels) {
-        return $false
-    }
-
-    return [bool]((Get-AgeDays -UpdatedAt $Pr.updatedAt) -ge $AgeDays)
-}
-
 function Write-CandidateReport {
     param(
         [Parameter(Mandatory)][hashtable]$Pr,
@@ -125,8 +101,8 @@ function Write-CandidateReport {
     $labels = @($Pr.labels | ForEach-Object { $_.name })
     $labelText = if ($labels.Count -gt 0) { ($labels | Sort-Object -Unique) -join ', ' } else { '(none)' }
     $age = Get-AgeDays -UpdatedAt $Pr.updatedAt
-    $authorObject = Get-PropertyValue -InputObject $Pr -Name 'author' -Default @{}
-    $author = if ($authorObject -is [System.Collections.IDictionary] -and $authorObject.Contains('login')) { [string]$authorObject['login'] } elseif ($authorObject -and $authorObject.PSObject.Properties['login']) { [string]$authorObject.login } else { '(unknown)' }
+    $authorObject = $Pr['author']
+    $author = if ($authorObject -and $authorObject.Contains('login')) { [string]$authorObject['login'] } else { '(unknown)' }
 
     return @(
         "PR #$($Pr.number): $($Pr.title)",
@@ -153,7 +129,7 @@ function Write-ReportLine {
 function Save-Report {
     param(
         [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][string[]]$Lines
+        [Parameter(Mandatory)][AllowEmptyString()][string[]]$Lines
     )
 
     $directory = Split-Path -Path $Path -Parent
@@ -161,28 +137,7 @@ function Save-Report {
         New-Item -ItemType Directory -Path $directory -Force | Out-Null
     }
 
-    $content = ($Lines -join [Environment]::NewLine)
-    [System.IO.File]::WriteAllText($Path, $content, [System.Text.UTF8Encoding]::new($false))
-}
-
-function Read-CommentFile {
-    param([Parameter(Mandatory)][string]$Path)
-
-    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-        throw "Comment file not found: $Path"
-    }
-
-    return Get-Content -LiteralPath $Path -Raw
-}
-
-function Test-CloseRequirements {
-    param(
-        [string]$CloseWithComment
-    )
-
-    if ($CloseWithComment -and -not (Test-Path -LiteralPath $CloseWithComment -PathType Leaf)) {
-        throw '-CloseWithComment requires a valid markdown file path.'
-    }
+    Set-Content -LiteralPath $Path -Value $Lines -Encoding utf8NoBOM
 }
 
 function Test-GhAuthentication {
@@ -194,32 +149,20 @@ function Test-GhAuthentication {
     }
 }
 
-function Add-PrComment {
-    param(
-        [Parameter(Mandatory)][hashtable]$Pr,
-        [Parameter(Mandatory)][string]$Repo,
-        [Parameter(Mandatory)][string]$CommentFile
-    )
-
-    $null = Read-CommentFile -Path $CommentFile
-    $command = @('pr', 'comment', [string]$Pr.number, '--repo', $Repo, '--body-file', $CommentFile)
-    $result = Invoke-GhCommand -Arguments $command
-
-    if ($result.ExitCode -ne 0) {
-        $message = ($result.Output | Out-String).Trim()
-        throw "Unable to comment on PR #$($Pr.number): $message"
-    }
-
-    return ($result.Output | Out-String)
-}
-
 function Close-PullRequest {
     param(
         [Parameter(Mandatory)][hashtable]$Pr,
-        [Parameter(Mandatory)][string]$Repo
+        [Parameter(Mandatory)][string]$Repo,
+        [ValidateScript({ -not $_ -or (Test-Path -LiteralPath $_ -PathType Leaf) })]
+        [string]$CommentFile
     )
 
     $command = @('pr', 'close', [string]$Pr.number, '--repo', $Repo)
+    if ($CommentFile) {
+        $comment = Get-Content -LiteralPath $CommentFile -Raw
+        $command += @('--comment', $comment)
+    }
+
     $result = Invoke-GhCommand -Arguments $command
 
     if ($result.ExitCode -ne 0) {
@@ -230,37 +173,26 @@ function Close-PullRequest {
     return ($result.Output | Out-String)
 }
 
-function Invoke-CommentAndClose {
-    param(
-        [Parameter(Mandatory)][hashtable]$Pr,
-        [Parameter(Mandatory)][string]$Repo,
-        [Parameter(Mandatory)][string]$CommentFile
-    )
-
-    Add-PrComment -Pr $Pr -Repo $Repo -CommentFile $CommentFile | Out-Null
-    Close-PullRequest -Pr $Pr -Repo $Repo | Out-Null
-}
-
 function Main {
     $reportLines = [System.Collections.Generic.List[string]]::new()
     $resolvedRepo = if ($env:GITHUB_REPOSITORY) { $env:GITHUB_REPOSITORY } else { $Repo }
 
     if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
         Write-Error "'gh' is not available on PATH."
-        exit 1
+        return 1
     }
 
     try {
-        Test-CloseRequirements -CloseWithComment $CloseWithComment
         Test-GhAuthentication
-        $prs = Get-GhPrList -Repo $resolvedRepo -Limit $Limit
+        $cutoffDate = (Get-Date).ToUniversalTime().AddDays(-$Age).ToString('yyyy-MM-dd', [System.Globalization.CultureInfo]::InvariantCulture)
+        $prs = Get-GhPrList -Repo $resolvedRepo -Limit $Limit -CutoffDate $cutoffDate
     }
     catch {
         Write-Error $_.Exception.Message
-        exit 1
+        return 1
     }
 
-    $stalePrs = @($prs | Where-Object { Test-StalePullRequest -Pr $_ -AgeDays $Age })
+    $stalePrs = @($prs | Sort-Object { [datetime]::Parse($_.updatedAt, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal) })
 
     if ($stalePrs.Count -eq 0) {
         Write-ReportLine -Text "No open PRs with no activity for $Age days or more found in $resolvedRepo." -ReportLines $reportLines
@@ -280,19 +212,17 @@ function Main {
 
         if ($CloseWithComment) {
             try {
-                Invoke-CommentAndClose -Pr $pr -Repo $resolvedRepo -CommentFile $CloseWithComment | Out-Null
+                Close-PullRequest -Pr $pr -Repo $resolvedRepo -CommentFile $CloseWithComment | Out-Null
                 Write-ReportLine -Text "  closed PR #$($pr.number) via gh pr close" -ReportLines $reportLines
             }
             catch {
                 $message = $_.Exception.Message
-                if ($message -like 'Unable to comment on PR #*') {
-                    Write-Error "Error commenting on PR #$($pr.number): $message"
-                }
-                else {
-                    Write-Error "Error closing PR #$($pr.number): $message"
-                }
-                exit 1
+                Write-Error "Error closing PR #$($pr.number): $message"
+                return 1
             }
+        }
+        else {
+            Write-ReportLine -Text "  would close PR #$($pr.number); pass -CloseWithComment to close it" -ReportLines $reportLines
         }
     }
 
@@ -302,5 +232,5 @@ function Main {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-    Main
+    exit (Main)
 }


### PR DESCRIPTION
* Move $CloseWithComment validation into the param
* Move validating the date ranges into the query rather than getting everything and filtering locally later
* Assume that PowerShell isn't silently changing types on us
* Use `gh pr close --comment` rather than separate close/comment actions that can race
* Be consistent about return/exit.
* Enforce that pwsh rather than Windows PowerShell is used.

GPT 5.5 and MAI-Code-1-Flash were used in preparing these changes.