### PR TITLE
[bbalouki-itch] Fix package integrations

### DIFF
--- a/ports/bbalouki-itch/fix-install-layout-and-dependencies.patch
+++ b/ports/bbalouki-itch/fix-install-layout-and-dependencies.patch
@@ -1,0 +1,37 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f7ad09a..efd32ac 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -22,9 +22,11 @@ add_library(
+ # Apache Arrow / Parquet columnar export is optional and off by default so the
+ # core library stays dependency-free. The arrow_export.cpp translation unit is
+ # empty unless ITCH_WITH_ARROW is defined.
++set(ITCH_CONFIG_FIND_DEPENDENCIES "")
+ if(${PROJECT_NAME}_WITH_ARROW)
+     find_package(Arrow CONFIG REQUIRED)
+     find_package(Parquet CONFIG REQUIRED)
++    set(ITCH_CONFIG_FIND_DEPENDENCIES "include(CMakeFindDependencyMacro)\nfind_dependency(Arrow CONFIG)\nfind_dependency(Parquet CONFIG)\n")
+     target_compile_definitions(itch PUBLIC ITCH_WITH_ARROW)
+ 
+     # Arrow's CMake config only exports the *_shared targets when Arrow was
+@@ -85,8 +87,8 @@ install(
+ 
+ # Step 4: Specify Header Destinations
+ install(
+-    DIRECTORY ${PROJECT_SOURCE_DIR}/include
+-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/itch
++    DIRECTORY ${PROJECT_SOURCE_DIR}/include/
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+ )
+ 
+ # Step 5: Export the Target Information
+diff --git a/src/cmake/ItchConfig.cmake.in b/src/cmake/ItchConfig.cmake.in
+index c02aa63..f55ca62 100644
+--- a/src/cmake/ItchConfig.cmake.in
++++ b/src/cmake/ItchConfig.cmake.in
+@@ -1,4 +1,5 @@
+ @PACKAGE_INIT@
+ 
++@ITCH_CONFIG_FIND_DEPENDENCIES@
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/ItchTargets.cmake")

--- a/ports/bbalouki-itch/portfile.cmake
+++ b/ports/bbalouki-itch/portfile.cmake
@@ -1,16 +1,16 @@
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bbalouki/itchcpp
     REF "v${VERSION}"
     SHA512 f35def9e84b68b47d4dd139a53243e263add0e706ee28548df3c4f89870fa6c383ca3a2b77dbd30a67d920f937ca0cc6b86cf80790f78037c98f3ac47d228420
     HEAD_REF main
+    PATCHES
+        fix-install-layout-and-dependencies.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         arrow ITCH_WITH_ARROW
-        python ITCH_BUILD_PYTHON
 )
 
 vcpkg_cmake_configure(
@@ -28,7 +28,6 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME "itch"
     CONFIG_PATH "lib/cmake/itch"
-   
 )
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()

--- a/ports/bbalouki-itch/vcpkg.json
+++ b/ports/bbalouki-itch/vcpkg.json
@@ -27,12 +27,6 @@
           ]
         }
       ]
-    },
-    "python": {
-      "description": "Build the pybind11 Python bindings",
-      "dependencies": [
-        "pybind11"
-      ]
     }
   }
 }

--- a/versions/b-/bbalouki-itch.json
+++ b/versions/b-/bbalouki-itch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c38597b9af6c0234c5f7c20e548ea24a862bf7c2",
+      "git-tree": "3b6f203a1f12b1a53053d3682b5d3c534b3c0b3c",
       "version": "1.6.2",
       "port-version": 0
     },


### PR DESCRIPTION
Applies the validated review patch on top of microsoft/vcpkg#52908.

Changes:
- Fixes the upstream header install layout so consumers can include `<itch/parser.hpp>` from the triplet root include directory.
- Adds Arrow/Parquet `find_dependency()` calls to the exported CMake config when the `arrow` feature is enabled.
- Removes the currently failing `python` feature and forces `ITCH_BUILD_PYTHON=OFF`.
- Updates the version database entry for `bbalouki-itch`.

Validated during review with patched core and `arrow` installs plus Debug/Release `find_package(itch CONFIG REQUIRED)` and direct include/link consumer checks.